### PR TITLE
Added sonarqube docker setup

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,13 +1,18 @@
-
 {$DOMAIN} {
 	redir /docs /docs/ permanent
 	redir /api /api/ permanent
+	redir /sonar /sonar/ permanent
 
 	handle_path /docs/* {
 		reverse_proxy http://api-docs
 	}
 	handle_path /api/* {
 		reverse_proxy http://mock-backend:8002
+	}
+	handle /sonar/* {
+		reverse_proxy http://sonarqube:9000 {
+			header_up Host {http.request.host}
+		}
 	}
 
 	reverse_proxy http://frontend:8000

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-
 services:
   frontend:
     image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
@@ -7,7 +6,7 @@ services:
       PUBLIC_API_BASE_URL: "https://${DOMAIN}/api"
     networks:
       - snowballr-network
-      
+
   api-docs:
     image: ghcr.io/se-uulm/snowballr-api/docs:main
     hostname: "api-docs"
@@ -38,6 +37,60 @@ services:
     networks:
       - snowballr-network
       - snowballr-host
+      - sonarqube-network
+
+  # SonarQube setup inspired by
+  # https://github.com/SonarSource/docker-sonarqube/blob/408a6865f494736d3a428e31d964271785f67d77/example-compose-files/sq-with-postgres/docker-compose.yml
+  sonarqube:
+    image: sonarqube:lts-community
+    hostname: sonarqube
+    container_name: sonarqube
+    read_only: true
+    ports:
+      - "9000:9000"
+    depends_on:
+      sonarqube-db:
+        condition: service_healthy
+    environment:
+      SONAR_JDBC_URL: jdbc:postgresql://sonarqube-db:5432/sonar
+      SONAR_JDBC_USERNAME: sonar
+      SONAR_JDBC_PASSWORD: sonar
+      SONAR_WEB_CONTEXT: /sonar
+      SONAR_TELEMETRY_ENABLE: false
+    volumes:
+      - sonarqube_data:/opt/sonarqube/data
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs
+      - sonarqube_temp:/opt/sonarqube/temp
+    networks:
+      - sonarqube-network
+
+  sonarqube-db:
+    image: postgres:17
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    hostname: sonarqube-postgresql
+    container_name: sonarqube-postgresql
+    environment:
+      POSTGRES_USER: sonar
+      POSTGRES_PASSWORD: sonar
+      POSTGRES_DB: sonar
+    volumes:
+      - sonarqube_postgresql:/var/lib/postgresql
+      - sonarqube_postgresql_data:/var/lib/postgresql/data
+    networks:
+      - sonarqube-network
+
+volumes:
+  sonarqube_data:
+  sonarqube_temp:
+  sonarqube_extensions:
+  sonarqube_logs:
+  sonarqube_postgresql:
+  sonarqube_postgresql_data:
 
 networks:
   snowballr-network:
@@ -45,10 +98,15 @@ networks:
     driver: ipvlan
     internal: true
     external: false
-    
+
   snowballr-host:
     name: snowballr-host
     driver: bridge
     internal: false
     external: false
-    
+
+  sonarqube-network:
+    name: sonarqube-network
+    driver: ipvlan
+    internal: true
+    external: false


### PR DESCRIPTION
Closes #4 

The SonarQube Server is now deployed on our server. It is deployed at https://snowballr.informatik.uni-ulm.de/sonar/.

The rest will be done either there or the backend repo itself.