### PR TITLE
Replace mock backend by backend with testing profile and deploy specific version of backend

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,14 +1,14 @@
 name: Deploy Development
 
 on:
-  workflow_dispatch:
-  schedule:
-    -   cron: "0 5 * * *" # Every night at 05:00 AM
-  push:
-    branches: [ "main" ]
+    workflow_dispatch:
+    schedule:
+        - cron: "0 5 * * *" # Every night at 05:00 AM
+    push:
+        branches: [ "main" ]
 
 jobs:
-  snowballr-deploy-dev:
-    uses: ./.github/workflows/deploy.yml
-    with:
-      profile: development
+    snowballr-deploy-dev:
+        uses: ./.github/workflows/deploy.yml
+        with:
+            profile: development

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,3 +12,4 @@ jobs:
         uses: ./.github/workflows/deploy.yml
         with:
             profile: development
+        secrets: inherit

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,14 @@
+name: Deploy Development
+
+on:
+  workflow_dispatch:
+  schedule:
+    -   cron: "0 5 * * *" # Every night at 05:00 AM
+  push:
+    branches: [ "main" ]
+
+jobs:
+  snowballr-deploy-dev:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      profile: development

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -9,3 +9,4 @@ jobs:
         uses: ./.github/workflows/deploy.yml
         with:
             profile: production
+        secrets: inherit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,11 +1,11 @@
 name: Deploy Production
 
 on:
-  push:
-    tags: ["v*.*.*"]
+    push:
+        tags: [ "v*.*.*" ]
 
 jobs:
-  snowballr-deploy-prod:
-    uses: ./.github/workflows/deploy.yml
-    with:
-      profile: production
+    snowballr-deploy-prod:
+        uses: ./.github/workflows/deploy.yml
+        with:
+            profile: production

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,11 @@
+name: Deploy Production
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  snowballr-deploy-prod:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      profile: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,15 @@
-name: Deploy
+name: Reusable Deploy Workflow
 
 on:
-    workflow_dispatch:
-    schedule:
-        - cron: "0 5 * * *" # Every night at 05:00 AM
-    push:
-        branches: ["main"]
+  workflow_call:
+    inputs:
+      profile:
+        required: true
+        type: string
 
 jobs:
     snowballr-deploy:
-        name: Deploy to Remote Server
+        name: Deploy (${{ inputs.profile }}) to Remote Server
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
@@ -33,5 +33,11 @@ jobs:
             - name: Login on Remote Machine
               run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- 'docker login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"'
 
-            - name: Start Docker Compose on Remote Machine
-              run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- 'cd "${{ vars.WORK_DIR }}" && export WORK_DIR="${{ vars.WORK_DIR }}" && export PROD_DOMAIN="${{ vars.REMOTE_DOMAIN }}" && export DEV_DOMAIN="${{ vars.REMOTE_DEV_DOMAIN }}" && docker compose up -d --pull always'
+            - name: Start Docker Compose with profile '${{ inputs.profile }}' on Remote Machine
+              run: |
+                ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" --
+                'cd "${{ vars.WORK_DIR }}" &&
+                export WORK_DIR="${{ vars.WORK_DIR }}" &&
+                export PROD_DOMAIN="${{ vars.REMOTE_DOMAIN }}" &&
+                export DEV_DOMAIN="${{ vars.REMOTE_DEV_DOMAIN }}" &&
+                docker compose --profile ${{ inputs.profile }} up -d --pull always'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,11 @@
 name: Reusable Deploy Workflow
 
 on:
-  workflow_call:
-    inputs:
-      profile:
-        required: true
-        type: string
+    workflow_call:
+        inputs:
+            profile:
+                required: true
+                type: string
 
 jobs:
     snowballr-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,11 +33,8 @@ jobs:
             - name: Login on Remote Machine
               run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- 'docker login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"'
 
+            - name: Setup environment variables
+              run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- 'echo export WORK_DIR="${{ vars.WORK_DIR }}" && export PROD_DOMAIN="${{ vars.REMOTE_DOMAIN }}" && export DEV_DOMAIN="${{ vars.REMOTE_DEV_DOMAIN }}"'
+
             - name: Start Docker Compose with profile '${{ inputs.profile }}' on Remote Machine
-              run: |
-                ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" --
-                'cd "${{ vars.WORK_DIR }}" &&
-                export WORK_DIR="${{ vars.WORK_DIR }}" &&
-                export PROD_DOMAIN="${{ vars.REMOTE_DOMAIN }}" &&
-                export DEV_DOMAIN="${{ vars.REMOTE_DEV_DOMAIN }}" &&
-                docker compose --profile ${{ inputs.profile }} up -d --pull always'
+              run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- 'cd "${{ vars.WORK_DIR }}" && docker compose --profile ${{ inputs.profile }} up -d --pull always'

--- a/Caddyfile
+++ b/Caddyfile
@@ -21,8 +21,8 @@
 	import docs-config
 
 	handle_path /api/* {
-		reverse_proxy http://backend-mock:9101
+		reverse_proxy http://proxy-development:9101
 	}
 
-	reverse_proxy http://frontend-mock:8001
+	reverse_proxy http://frontend-development:8001
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,13 +10,33 @@ services:
     profiles:
         - production
 
-  frontend-mock:
-    image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
-    env_file: frontend-mock.env
-    networks:
-    - snowballr-network
-    profiles:
-        - development
+  backend:
+      image: ghcr.io/se-uulm/snowballr-backend:0.1.0
+      env_file: backend.env
+      networks:
+          - snowballr-network
+          - snowballr-host # to communicate with the email server
+      profiles:
+          - production
+
+  proxy:
+      build:
+          context: .
+          dockerfile: Dockerfile.proxy
+      ports:
+          - "9100:9100"
+      command:
+          # Point to the backend on the machine's host
+          - --backend_addr=backend:9000
+          - --allowed_origins=http?://${PROD_DOMAIN}
+          - --run_tls_server=false # Don't require TLS Handled by proxy
+          - --server_http_debug_port=9100
+          - --server_http_max_write_timeout=30s
+          - --server_http_max_read_timeout=30s
+      networks:
+          - snowballr-network
+      profiles:
+          - production
 
   frontend:
     image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
@@ -26,29 +46,58 @@ services:
     profiles:
        - production
 
+  database-development:
+      image: postgres:16.1-alpine3.19
+      env_file: database-development.env
+      volumes:
+          - ${WORK_DIR:?error}/database-development:/var/lib/postgresql/data
+      networks:
+          - snowballr-network
+      profiles:
+          - development
+
+  backend-development:
+      image: ghcr.io/se-uulm/snowballr-backend:latest-dev
+      env_file: backend-development.env
+      networks:
+          - snowballr-network
+          - snowballr-host # to communicate with the email server
+      profiles:
+          - development
+
+  proxy-development:
+      build:
+          context: .
+          dockerfile: Dockerfile.proxy
+      ports:
+          - "9101:9101"
+      command:
+          # Point to the backend on the machine's host
+          - --backend_addr=backend:9001
+          - --allowed_origins=http?://${DEV_DOMAIN}
+          - --run_tls_server=false # Don't require TLS Handled by proxy
+          - --server_http_debug_port=9101
+          - --server_http_max_write_timeout=30s
+          - --server_http_max_read_timeout=30s
+      networks:
+          - snowballr-network
+      profiles:
+          - development
+
+  frontend-development:
+      image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
+      env_file: frontend-development.env
+      networks:
+          - snowballr-network
+      profiles:
+          - development
+
   api-docs:
     image: ghcr.io/se-uulm/snowballr-api/docs:main
     hostname: "api-docs"
     networks:
       - snowballr-network
     profiles: [""]
-
-  backend-mock:
-    image: ghcr.io/se-uulm/snowballr-mock-backend:main
-    env_file: backend-mock.env
-    networks:
-        - snowballr-network
-    profiles:
-        - development
-
-  backend:
-    image: ghcr.io/se-uulm/snowballr-backend:latest-dev
-    env_file: backend.env
-    networks:
-      - snowballr-network
-      - snowballr-host # to communicate with the email server
-    profiles:
-        - production
 
   caddy:
     image: caddy:2.10.0
@@ -67,25 +116,6 @@ services:
       - snowballr-network
       - snowballr-host # to communicate with the client
     profiles: [""]
-
-  proxy:
-    build:
-        context: .
-        dockerfile: Dockerfile.proxy
-    ports:
-        - "9100:9100"
-    command:
-        # Point to the backend on the machine's host
-        - --backend_addr=backend:9000
-        - --allowed_origins=http?://${PROD_DOMAIN}
-        - --run_tls_server=false # Don't require TLS Handled by proxy
-        - --server_http_debug_port=9100
-        - --server_http_max_write_timeout=30s
-        - --server_http_max_read_timeout=30s
-    networks:
-        - snowballr-network
-    profiles:
-        - production
 
 networks:
   snowballr-network:

--- a/compose.yaml
+++ b/compose.yaml
@@ -73,7 +73,7 @@ services:
           - "9101:9101"
       command:
           # Point to the backend on the machine's host
-          - --backend_addr=backend:9001
+          - --backend_addr=backend-development:9001
           - --allowed_origins=http?://${DEV_DOMAIN}
           - --run_tls_server=false # Don't require TLS Handled by proxy
           - --server_http_debug_port=9101
@@ -97,7 +97,6 @@ services:
     hostname: "api-docs"
     networks:
       - snowballr-network
-    profiles: [""]
 
   caddy:
     image: caddy:2.10.0
@@ -115,7 +114,6 @@ services:
     networks:
       - snowballr-network
       - snowballr-host # to communicate with the client
-    profiles: [""]
 
 networks:
   snowballr-network:

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
             - production
 
     backend:
-        image: ghcr.io/se-uulm/snowballr-backend:0.1.0
+        image: ghcr.io/se-uulm/snowballr-backend:0.1.0 # update to v<major>.<minor>.<patch> when using the next backend version and remove this comment
         env_file: backend.env
         networks:
             - snowballr-network

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,30 +7,39 @@ services:
         - ${WORK_DIR:?error}/database:/var/lib/postgresql/data
     networks:
         - snowballr-network
+    profiles:
+        - production
 
   frontend-mock:
     image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
     env_file: frontend-mock.env
     networks:
     - snowballr-network
+    profiles:
+        - development
 
   frontend:
     image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
     env_file: frontend.env
     networks:
       - snowballr-network
+    profiles:
+       - production
 
   api-docs:
     image: ghcr.io/se-uulm/snowballr-api/docs:main
     hostname: "api-docs"
     networks:
       - snowballr-network
+    profiles: [""]
 
   backend-mock:
     image: ghcr.io/se-uulm/snowballr-mock-backend:main
     env_file: backend-mock.env
     networks:
         - snowballr-network
+    profiles:
+        - development
 
   backend:
     image: ghcr.io/se-uulm/snowballr-backend:latest-dev
@@ -38,6 +47,9 @@ services:
     networks:
       - snowballr-network
       - snowballr-host # to communicate with the email server
+    profiles:
+        - production
+
   caddy:
     image: caddy:2.10.0
     environment:
@@ -54,6 +66,7 @@ services:
     networks:
       - snowballr-network
       - snowballr-host # to communicate with the client
+    profiles: [""]
 
   proxy:
     build:
@@ -71,6 +84,8 @@ services:
         - --server_http_max_read_timeout=30s
     networks:
         - snowballr-network
+    profiles:
+        - production
 
 networks:
   snowballr-network:

--- a/compose.yaml
+++ b/compose.yaml
@@ -92,7 +92,7 @@ services:
             - development
 
     api-docs:
-        image: ghcr.io/se-uulm/snowballr-api/docs:main
+        image: ghcr.io/se-uulm/snowballr-api:latest
         hostname: "api-docs"
         networks:
             - snowballr-network

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,127 +1,126 @@
-
 services:
-  database:
-    image: postgres:16.1-alpine3.19
-    env_file: database.env
-    volumes:
-        - ${WORK_DIR:?error}/database:/var/lib/postgresql/data
-    networks:
-        - snowballr-network
-    profiles:
-        - production
+    database:
+        image: postgres:16.1-alpine3.19
+        env_file: database.env
+        volumes:
+            - ${WORK_DIR:?error}/database:/var/lib/postgresql/data
+        networks:
+            - snowballr-network
+        profiles:
+            - production
 
-  backend:
-      image: ghcr.io/se-uulm/snowballr-backend:0.1.0
-      env_file: backend.env
-      networks:
-          - snowballr-network
-          - snowballr-host # to communicate with the email server
-      profiles:
-          - production
+    backend:
+        image: ghcr.io/se-uulm/snowballr-backend:0.1.0
+        env_file: backend.env
+        networks:
+            - snowballr-network
+            - snowballr-host # to communicate with the email server
+        profiles:
+            - production
 
-  proxy:
-      build:
-          context: .
-          dockerfile: Dockerfile.proxy
-      ports:
-          - "9100:9100"
-      command:
-          # Point to the backend on the machine's host
-          - --backend_addr=backend:9000
-          - --allowed_origins=http?://${PROD_DOMAIN}
-          - --run_tls_server=false # Don't require TLS Handled by proxy
-          - --server_http_debug_port=9100
-          - --server_http_max_write_timeout=30s
-          - --server_http_max_read_timeout=30s
-      networks:
-          - snowballr-network
-      profiles:
-          - production
+    proxy:
+        build:
+            context: .
+            dockerfile: Dockerfile.proxy
+        ports:
+            - "9100:9100"
+        command:
+            # Point to the backend on the machine's host
+            - --backend_addr=backend:9000
+            - --allowed_origins=http?://${PROD_DOMAIN}
+            - --run_tls_server=false # Don't require TLS Handled by proxy
+            - --server_http_debug_port=9100
+            - --server_http_max_write_timeout=30s
+            - --server_http_max_read_timeout=30s
+        networks:
+            - snowballr-network
+        profiles:
+            - production
 
-  frontend:
-    image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
-    env_file: frontend.env
-    networks:
-      - snowballr-network
-    profiles:
-       - production
+    frontend:
+        image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
+        env_file: frontend.env
+        networks:
+            - snowballr-network
+        profiles:
+            - production
 
-  database-development:
-      image: postgres:16.1-alpine3.19
-      env_file: database-development.env
-      volumes:
-          - ${WORK_DIR:?error}/database-development:/var/lib/postgresql/data
-      networks:
-          - snowballr-network
-      profiles:
-          - development
+    database-development:
+        image: postgres:16.1-alpine3.19
+        env_file: database-development.env
+        volumes:
+            - ${WORK_DIR:?error}/database-development:/var/lib/postgresql/data
+        networks:
+            - snowballr-network
+        profiles:
+            - development
 
-  backend-development:
-      image: ghcr.io/se-uulm/snowballr-backend:latest-dev
-      env_file: backend-development.env
-      networks:
-          - snowballr-network
-          - snowballr-host # to communicate with the email server
-      profiles:
-          - development
+    backend-development:
+        image: ghcr.io/se-uulm/snowballr-backend:latest-dev
+        env_file: backend-development.env
+        networks:
+            - snowballr-network
+            - snowballr-host # to communicate with the email server
+        profiles:
+            - development
 
-  proxy-development:
-      build:
-          context: .
-          dockerfile: Dockerfile.proxy
-      ports:
-          - "9101:9101"
-      command:
-          # Point to the backend on the machine's host
-          - --backend_addr=backend-development:9001
-          - --allowed_origins=http?://${DEV_DOMAIN}
-          - --run_tls_server=false # Don't require TLS Handled by proxy
-          - --server_http_debug_port=9101
-          - --server_http_max_write_timeout=30s
-          - --server_http_max_read_timeout=30s
-      networks:
-          - snowballr-network
-      profiles:
-          - development
+    proxy-development:
+        build:
+            context: .
+            dockerfile: Dockerfile.proxy
+        ports:
+            - "9101:9101"
+        command:
+            # Point to the backend on the machine's host
+            - --backend_addr=backend-development:9001
+            - --allowed_origins=http?://${DEV_DOMAIN}
+            - --run_tls_server=false # Don't require TLS Handled by proxy
+            - --server_http_debug_port=9101
+            - --server_http_max_write_timeout=30s
+            - --server_http_max_read_timeout=30s
+        networks:
+            - snowballr-network
+        profiles:
+            - development
 
-  frontend-development:
-      image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
-      env_file: frontend-development.env
-      networks:
-          - snowballr-network
-      profiles:
-          - development
+    frontend-development:
+        image: ghcr.io/se-uulm/snowballr-frontend:latest-dev
+        env_file: frontend-development.env
+        networks:
+            - snowballr-network
+        profiles:
+            - development
 
-  api-docs:
-    image: ghcr.io/se-uulm/snowballr-api/docs:main
-    hostname: "api-docs"
-    networks:
-      - snowballr-network
+    api-docs:
+        image: ghcr.io/se-uulm/snowballr-api/docs:main
+        hostname: "api-docs"
+        networks:
+            - snowballr-network
 
-  caddy:
-    image: caddy:2.10.0
-    environment:
-      PROD_DOMAIN: ${PROD_DOMAIN:?error}
-      DEV_DOMAIN: ${DEV_DOMAIN:?error}
-    ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp"
-    volumes:
-      - ${WORK_DIR:?error}/Caddyfile:/etc/caddy/Caddyfile
-      - ${WORK_DIR:?error}/runtime/caddy/data:/data
-      - ${WORK_DIR:?error}/runtime/caddy/config:/config
-    networks:
-      - snowballr-network
-      - snowballr-host # to communicate with the client
+    caddy:
+        image: caddy:2.10.0
+        environment:
+            PROD_DOMAIN: ${PROD_DOMAIN:?error}
+            DEV_DOMAIN: ${DEV_DOMAIN:?error}
+        ports:
+            - "80:80"
+            - "443:443"
+            - "443:443/udp"
+        volumes:
+            - ${WORK_DIR:?error}/Caddyfile:/etc/caddy/Caddyfile
+            - ${WORK_DIR:?error}/runtime/caddy/data:/data
+            - ${WORK_DIR:?error}/runtime/caddy/config:/config
+        networks:
+            - snowballr-network
+            - snowballr-host # to communicate with the client
 
 networks:
-  snowballr-network:
-    name: snowballr-network
-    driver: bridge
-    internal: true
+    snowballr-network:
+        name: snowballr-network
+        driver: bridge
+        internal: true
 
-  snowballr-host:
-    name: snowballr-host
-    driver: bridge
-    internal: false
+    snowballr-host:
+        name: snowballr-host
+        driver: bridge
+        internal: false

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -164,15 +164,17 @@ flowchart TB
 ## Versioning Guideline
 
 For the versioning we follow [Semantic Versioning](https://semver.org/).
-When a new version should be published, document the changes in a changelog (following the guidelines of
-[Common Changelog](https://common-changelog.org/)), tag the code in Git and a release will be automatically created and
-published.
+Whenever a new version of the application should be released, for example, due to new features, important bug fixes,
+or general changes in the frontend or backend, a new release is created.
 
 > **Note:** At the moment the [Frontend](https://github.com/SE-UUlm/snowballr-frontend) is not versioned.
 
 ### Release Procedure
 
-When a new version should be released, follow these steps:
+A new release includes documenting all relevant changes in the _CHANGELOG.md_ and ensuring that the deployment
+configuration in the _compose.yml_ for the production backend references the desired backend version / tag.
+
+When a new version of the **SnowballR** web application should be released, follow these steps:
 
 1. Create a release branch for the release:
 
@@ -199,9 +201,11 @@ When a new version should be released, follow these steps:
    [`Release`](https://github.com/SE-UUlm/snowballr-ci/wiki/Getting-Started#release) workflow from our CI repository to
    ensure a consistent changelog format and automatic release creation.
 
-5. Create a pull request and request a review.
+5. Update the tag of the _snowballr-backend_ image in the _compose.yml_ to the new version.
 
-6. After the pull request is merged, create a tag with the same version - so "vX.Y.Z" - at the merge commit.
+6. Create a pull request and request a review.
+
+7. After the pull request is merged, create a tag with the same version - so "vX.Y.Z" - at the merge commit.
 
    ```bash
    git pull main|develop
@@ -209,7 +213,7 @@ When a new version should be released, follow these steps:
    git push origin vX.Y.Z
    ```
 
-7. Then the CI automatically creates a new release.
+7. Then the CI automatically creates a new release and deploys the new application version to the production server.
 
 ## Teamscale Integration
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -102,7 +102,7 @@ for permanent data storage. All database files are stored under `${WORK_DIR}/dat
 `${WORK_DIR}/database-development`, respectively.
 The database services are not exposed publicly and cannot be accessed directly by external PostgreSQL clients.
 The `*-development` services are used for development as they always use the latest version of the backend
-and frontend and must not be stable and contain user data expect for testing data.
+and frontend and must not be stable and contain testing data.
 
 #### Networks
 
@@ -114,7 +114,7 @@ and frontend and must not be stable and contain user data expect for testing dat
 
 ### Routing
 
-Caddy handles incoming HTTP(S) traffic and route requests based on the configured domain and path.
+Caddy handles incoming HTTP(S) traffic and routes requests based on the configured domain and path.
 Two domains are in use: one for the production deployment
 ([snowballr.informatik.uni-ulm.de](https://snowballr.informatik.uni-ulm.de/)),
 which serves the end-user version of the application, and one for the development deployment
@@ -135,7 +135,7 @@ flowchart TB
         Backend["backend<br/>(9000)"]
         Database["database<br/>(5432)"]
         ProxyDev["proxy-development<br/>(9101)"]
-        BackendDev["backend<br/>(9001)"]
+        BackendDev["backend-development<br/>(9001)"]
         DatabaseDev["database-development<br/>(5432)"]
         ApiDocs["api-docs<br/>(80)"]
     end
@@ -172,7 +172,7 @@ or general changes in the frontend or backend, a new release is created.
 ### Release Procedure
 
 A new release includes documenting all relevant changes in the _CHANGELOG.md_ and ensuring that the deployment
-configuration in the _compose.yml_ for the production backend references the desired backend version / tag.
+configuration in the _compose.yaml_ for the production backend references the desired backend version / tag.
 
 When a new version of the **SnowballR** web application should be released, follow these steps:
 
@@ -201,7 +201,7 @@ When a new version of the **SnowballR** web application should be released, foll
    [`Release`](https://github.com/SE-UUlm/snowballr-ci/wiki/Getting-Started#release) workflow from our CI repository to
    ensure a consistent changelog format and automatic release creation.
 
-5. Update the tag of the _snowballr-backend_ image in the _compose.yml_ to the new version.
+5. Update the tag of the _snowballr-backend_ image in the _compose.yaml_ to the new version.
 
 6. Create a pull request and request a review.
 
@@ -213,7 +213,7 @@ When a new version of the **SnowballR** web application should be released, foll
    git push origin vX.Y.Z
    ```
 
-7. Then the CI automatically creates a new release and deploys the new application version to the production server.
+Then the CI automatically creates a new release and deploys the new application version to the production server.
 
 ## Teamscale Integration
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -164,17 +164,16 @@ flowchart TB
 ## Versioning Guideline
 
 For the versioning we follow [Semantic Versioning](https://semver.org/).
-Whenever a new version of the application should be released, for example, due to new features, important bug fixes,
-or general changes in the frontend or backend, a new release is created.
+When a new version should be published, for example, due to new features, important bug fixes,
+or general changes, document the changes in a changelog (following the guidelines of
+[Common Changelog](https://common-changelog.org/)), tag the code in Git and a release will be automatically created and
+published.
 
 > **Note:** At the moment the [Frontend](https://github.com/SE-UUlm/snowballr-frontend) is not versioned.
 
 ### Release Procedure
 
-A new release includes documenting all relevant changes in the _CHANGELOG.md_ and ensuring that the deployment
-configuration in the _compose.yaml_ for the production backend references the desired backend version / tag.
-
-When a new version of the **SnowballR** web application should be released, follow these steps:
+When a new version should be released, follow these steps:
 
 1. Create a release branch for the release:
 
@@ -201,11 +200,9 @@ When a new version of the **SnowballR** web application should be released, foll
    [`Release`](https://github.com/SE-UUlm/snowballr-ci/wiki/Getting-Started#release) workflow from our CI repository to
    ensure a consistent changelog format and automatic release creation.
 
-5. Update the tag of the _snowballr-backend_ image in the _compose.yaml_ to the new version.
+5. Create a pull request and request a review.
 
-6. Create a pull request and request a review.
-
-7. After the pull request is merged, create a tag with the same version - so "vX.Y.Z" - at the merge commit.
+6. After the pull request is merged, create a tag with the same version - so "vX.Y.Z" - at the merge commit.
 
    ```bash
    git pull main|develop
@@ -213,7 +210,12 @@ When a new version of the **SnowballR** web application should be released, foll
    git push origin vX.Y.Z
    ```
 
-Then the CI automatically creates a new release and deploys the new application version to the production server.
+7. Then the CI automatically creates a new release.
+
+When a new version of the entire **SnowballR** web application should be released, ensure that the deployment
+configuration in the _compose.yaml_ for the production backend references the desired backend version / tag.
+The deployment of the new application to the production server is performed automatically after tagging the new
+version of the **SnowballR** application.
 
 ## Teamscale Integration
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -16,9 +16,9 @@ On this page, we explain how to contribute to the SnowballR project. We cover th
 ### Workflow
 
 Starting from an issue, we create a branch with the name of the issue (see [Commits & Branches](#commits--branches)).
-It's up to you, whether you create a draft pull request immediately or wait until you are finished with the
+It's up to you whether you create a draft pull request immediately or wait until you are finished with the
 implementation. While creating a draft pull request gives you direct feedback from the CI/CD pipeline, it also clutters
-the pull request list. So it's up to you whether you want to create a draft pull request or not.
+the pull request list.
 
 When starting to work on an issue, ensure that the issue is assigned to you and part of our project SnowballR.
 Furthermore, make sure you set the status to `In progress` and the iteration to the current one (if that is not already

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -90,7 +90,7 @@ The deployment setup requires the following environment variables:
 | `proxy`                | Production gRPC proxy that forwards to backend              | `9100`     |
 | `proxy-development`    | Development gRPC proxy that forwards to development backend | `9101`     |
 | `backend`              | Production backend                                          | `9000`     |
-| `backend-development`  | Development backend                                         | `9101`     |
+| `backend-development`  | Development backend                                         | `9001`     |
 | `database`             | PostgreSQL database for the production backend              | `5432`     |
 | `database-development` | PostgreSQL database for the development backend             | `5432`     |
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -63,13 +63,15 @@ This project uses [Docker](https://www.docker.com/) for local and production dep
 via [Docker Compose](https://docs.docker.com/compose/), with [Caddy](https://caddyserver.com/) serving as a reverse
 proxy to route HTTP traffic to the appropriate services.
 
-At the moment, deployments are performed nightly, always using the latest version of the API and the current state of
-the `develop` branch of the [frontend](https://github.com/SE-UUlm/snowballr-frontend/tree/develop) and
-[backend](https://github.com/SE-UUlm/snowballr-backend/tree/develop) /
-[mock backend](https://github.com/SE-UUlm/snowballr-mock-backend/tree/main).
+At the moment, we distinguish two deployments.
 
-> **Note:** In the future, the versions should be pinned to and aligned with releases of the system parts to ensure
-> stability and reproducibility.
+- **Production deployment** (`deploy-prod.yml`): The production version of the **SnowballR** application is deployed
+whenever a new version of the application is released in this repository by creating a new tag.
+The production version uses the latest version of the frontend, and the specific, tagged version of the backend.
+- **Development deployment** (`deploy-dev.yml`): The deployment of the development version is performed nightly or
+manually. It always uses the latest version of the frontend as well as backend.
+
+The latest version of the frontend / backend is indicated by the `latest-dev` tag.
 
 The deployment setup requires the following environment variables:
 
@@ -79,41 +81,45 @@ The deployment setup requires the following environment variables:
 
 ### Service Overview
 
-| Service         | Description / usage (short)                    | Port       |
-| --------------- | ---------------------------------------------- | ---------- |
-| `caddy`         | Public reverse-proxy & TLS certification       | `80`,`443` |
-| `frontend`      | Production Svelte GUI                          | `8000`     |
-| `frontend-mock` | Development Svelte GUI (testing)               | `8001`     |
-| `api-docs`      | gRPC API documentation site                    | `80`       |
-| `proxy`         | Production gRPC proxy that forwards to backend | `9100`     |
-| `backend`       | Production backend                             | `9000`     |
-| `backend-mock`  | Mock backend                                   | `9101`     |
-| `database`      | PostgreSQL database                            | `5432`     |
+| Service                | Description / usage (short)                                 | Port       |
+|------------------------|-------------------------------------------------------------|------------|
+| `caddy`                | Public reverse-proxy & TLS certification                    | `80`,`443` |
+| `frontend`             | Production Svelte GUI                                       | `8000`     |
+| `frontend-development` | Development Svelte GUI (testing)                            | `8001`     |
+| `api-docs`             | gRPC API documentation site                                 | `80`       |
+| `proxy`                | Production gRPC proxy that forwards to backend              | `9100`     |
+| `proxy-development`    | Development gRPC proxy that forwards to development backend | `9101`     |
+| `backend`              | Production backend                                          | `9000`     |
+| `backend-development`  | Development backend                                         | `9101`     |
+| `database`             | PostgreSQL database for the production backend              | `5432`     |
+| `database-development` | PostgreSQL database for the development backend             | `5432`     |
 
 > **Note:** the _Port_ column lists only container ports, not host-published ports. Only `caddy` and `proxy` publish
-> ports: `80`, `443`, `443/udp` or `9100`, respectively.
+> ports: `80`, `443`, `443/udp` or `9100` / `9101`, respectively.
 
-The `backend-mock` service operates entirely in-memory and does not persist data.
-In contrast, the `backend` service relies on the `database` service (PostgreSQL) for permanent data storage.
-All database files are stored under `${WORK_DIR}/database`.
-The `database` service is not exposed publicly and cannot be accessed directly by external PostgreSQL clients.
+The `backend` / `backend-development` service relies on the `database` / `database-development` service (PostgreSQL)
+for permanent data storage. All database files are stored under `${WORK_DIR}/database` or
+`${WORK_DIR}/database-development`, respectively.
+The database services are not exposed publicly and cannot be accessed directly by external PostgreSQL clients.
+The `*-development` services are used for development as they always use the latest version of the backend
+and frontend and must not be stable and contain user data expect for testing data.
 
 #### Networks
 
 - `snowballr-network` — Internal bridge network for communication between application services. All services are
-  attached to this network and this network cannot be accessed from outside the Docker environment.
+  attached to this network, and this network cannot be accessed from outside the Docker environment.
 - `snowballr-host` — Bridge network that provides access to the Docker host and external services.
   It is used by the `caddy` service to communicate with external clients and by the `backend` service to interact with
   the host’s email server.
 
 ### Routing
 
-Caddy handles incoming HTTP(S) traffic and routes requests based on the configured domain and path.
+Caddy handles incoming HTTP(S) traffic and route requests based on the configured domain and path.
 Two domains are in use: one for the production deployment
 ([snowballr.informatik.uni-ulm.de](https://snowballr.informatik.uni-ulm.de/)),
 which serves the end-user version of the application, and one for the development deployment
 ([snowballr-dev.informatik.uni-ulm.de](https://snowballr-dev.informatik.uni-ulm.de/)),
-which is used to test new features (currently with the mock backend).
+which is used to test new features (currently with the latest backend and the development profile).
 
 ```mermaid
 flowchart TB
@@ -124,29 +130,35 @@ flowchart TB
     subgraph SN["snowballr-network (internal)"]
         Caddy["caddy<br/>(80 / 443)"]
         Frontend["frontend<br/>(8000)"]
-        FrontendMock["frontend-mock<br/>(8001)"]
-        ApiDocs["api-docs<br/>(80)"]
+        FrontendDev["frontend-development<br/>(8001)"]
         Proxy["proxy<br/>(9100)"]
         Backend["backend<br/>(9000)"]
-        BackendMock["backend-mock<br/>(9101)"]
         Database["database<br/>(5432)"]
+        ProxyDev["proxy-development<br/>(9101)"]
+        BackendDev["backend<br/>(9001)"]
+        DatabaseDev["database-development<br/>(5432)"]
+        ApiDocs["api-docs<br/>(80)"]
     end
 
     Mail[Email Server]
 
     %% Connections inside snowballr-network
     Caddy -->|"${PROD_DOMAIN}/"| Frontend
-    Caddy -->|"${DEV_DOMAIN}/"| FrontendMock
-    Caddy -->|"\*/docs/*"| ApiDocs
+    Caddy -->|"${DEV_DOMAIN}/"| FrontendDev
     Caddy -->|"${PROD_DOMAIN}/api/*"| Proxy
-    Caddy -->|"${DEV_DOMAIN}/api/*"| BackendMock
+    Caddy -->|"${DEV_DOMAIN}/api/*"| ProxyDev
+    Caddy -->|"\*/docs/*"| ApiDocs
 
     Proxy --> Backend
     Backend --> Database
 
+    ProxyDev --> BackendDev
+    BackendDev --> DatabaseDev
+
     %% External communications
     Client -->|HTTP / HTTPS| Caddy
     Backend -->|SMTP| Mail
+    BackendDev -->|SMTP| Mail
 ```
 
 ## Versioning Guideline


### PR DESCRIPTION
Closes #34 

## What I've done

- I converted the `snowball-deploy` workflow into a reusable and parametric workflow, that sets up the ssh connection, logs into the remote server, copy all necessary files and start the compose file with a given profile
- I added two new workflows that start a development deployment nightly or on pushes to main or manually using the `development` profile or the production deployment on tags using the `production` profile
- I adapted the deployment description in the `Contributing.md` file to reflect the new changes
- I created a backup of the old environment files for the mock backend deployment and created new environment files for the development backend
- I added a release guideline for application releases (to be extended in the future, only as start)
- I adapted the environment files on the snowballr server