### PR TITLE
Fixed environment variables not persisted over multiple ssh sessions

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,7 +5,7 @@ on:
     schedule:
         - cron: "0 5 * * *" # Every night at 05:00 AM
     push:
-        branches: [ "main" ]
+        branches: ["main"]
 
 jobs:
     snowballr-deploy-dev:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,7 +2,7 @@ name: Deploy Production
 
 on:
     push:
-        tags: [ "v*.*.*" ]
+        tags: ["v*.*.*"]
 
 jobs:
     snowballr-deploy-prod:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,17 +24,26 @@ jobs:
                   echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
                   chmod 600 ~/.ssh/id_rsa
 
-            # - name: Stop Previous Deployment
-            #   run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- docker compose -p snowballr-deploy down
-
             - name: Copy Config Files
               run: scp ./{Caddyfile,Dockerfile.proxy,compose.yaml} "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}:${{ vars.WORK_DIR }}/"
 
-            - name: Login on Remote Machine
-              run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- 'docker login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"'
+            - name: Deploy '${{ inputs.profile }}' Profile on Remote Machine
+              uses: appleboy/ssh-action@v1
+              env:
+                  WORK_DIR: ${{ vars.WORK_DIR }}
+                  PROD_DOMAIN: ${{ vars.REMOTE_DOMAIN }}
+                  DEV_DOMAIN: ${{ vars.REMOTE_DEV_DOMAIN }}
+              with:
+                  host: ${{ vars.REMOTE_DOMAIN }}
+                  username: ${{ vars.REMOTE_USER }}
+                  key: ${{ secrets.SSH_PRIVATE_KEY }}
+                  envs: WORK_DIR,PROD_DOMAIN,DEV_DOMAIN
+                  script: |
+                      cd $WORK_DIR
 
-            - name: Setup environment variables
-              run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- 'echo export WORK_DIR="${{ vars.WORK_DIR }}" && export PROD_DOMAIN="${{ vars.REMOTE_DOMAIN }}" && export DEV_DOMAIN="${{ vars.REMOTE_DEV_DOMAIN }}"'
+                      # GHCR Login
+                      echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-            - name: Start Docker Compose with profile '${{ inputs.profile }}' on Remote Machine
-              run: ssh "${{ vars.REMOTE_USER }}@${{ vars.REMOTE_DOMAIN }}" -- 'cd "${{ vars.WORK_DIR }}" && docker compose --profile ${{ inputs.profile }} up -d --pull always'
+                      # Start containers
+                      echo "Starting '${{ inputs.profile }}' deployment"
+                      docker compose --profile "${{ inputs.profile }}" up -d --pull always --remove-orphans


### PR DESCRIPTION
Closes #48 

So the problem wasn't the different GitHub Actions job steps in which we did the exporting of environment variables but rather that each SSH command opens a new session in which the env variables are only stored temporarily. To fix this, I now temporarily stored them in a file so that the Docker command can use it. Another option would be to put it inside the same SSH command, which will be harder to read.

Edit: I went for the `ssh-action` GH Action since it handles the things we want, and the commands are now easy to read, which I think is most important for further maintenance. Additionally, we easily can inject env variables.

See the last [action run](https://github.com/SE-UUlm/snowballr/actions/runs/20311394305/job/58343323358)